### PR TITLE
#137 관리자 > 공지 관리 > 공지 상세 조회

### DIFF
--- a/src/main/java/com/tikitaka/triptroop/admin/controller/AdminCategoryController.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/controller/AdminCategoryController.java
@@ -1,6 +1,7 @@
 package com.tikitaka.triptroop.admin.controller;
 
 import com.tikitaka.triptroop.admin.dto.request.AdminCategorySaveRequest;
+import com.tikitaka.triptroop.admin.dto.response.AdminCategoryResponse;
 import com.tikitaka.triptroop.admin.service.AdminCategoryService;
 import com.tikitaka.triptroop.category.domain.entity.Category;
 import com.tikitaka.triptroop.common.dto.response.ApiResponse;
@@ -22,7 +23,7 @@ public class AdminCategoryController {
     /* 1. 카테고리 관리 > 카테고리 목록 조회 */
     @GetMapping("")
     public ResponseEntity<ApiResponse<?>> getCategoryList() {
-        final List<Category> categoryList = adminCategoryService.getCategoryList();
+        final List<AdminCategoryResponse> categoryList = adminCategoryService.getCategoryList();
         return ResponseEntity.ok(ApiResponse.success("카테고리 목록 조회에 성공하였습니다.", categoryList));
     }
 

--- a/src/main/java/com/tikitaka/triptroop/admin/controller/AdminInquiryController.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/controller/AdminInquiryController.java
@@ -24,7 +24,7 @@ public class AdminInquiryController {
 
     /* 1. 문의 관리 > 문의 목록 조회 */
     @GetMapping("")
-    public ResponseEntity<ApiResponse> getInquriryList() {
+    public ResponseEntity<ApiResponse> getInquiryList() {
         final List<AdminInquiryListResponse> inquryList = inquiryService.getInquriryList();
         return ResponseEntity.ok(ApiResponse.success("문의 목록 조회에 성공하였습니다.", inquryList));
     }

--- a/src/main/java/com/tikitaka/triptroop/admin/controller/AdminInquiryController.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/controller/AdminInquiryController.java
@@ -1,11 +1,11 @@
 package com.tikitaka.triptroop.admin.controller;
 
 
+import com.tikitaka.triptroop.admin.dto.request.AdminInquiryReplyRequest;
 import com.tikitaka.triptroop.admin.dto.response.AdminInquiryDetailResponse;
 import com.tikitaka.triptroop.admin.dto.response.AdminInquiryListResponse;
 import com.tikitaka.triptroop.admin.service.AdminInquiryService;
 import com.tikitaka.triptroop.common.dto.response.ApiResponse;
-import com.tikitaka.triptroop.image.dto.request.AdminInquiryReplyRequest;
 import com.tikitaka.triptroop.inquiry.domain.entity.Inquiry;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/tikitaka/triptroop/admin/controller/AdminNoticeController.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/controller/AdminNoticeController.java
@@ -1,12 +1,14 @@
 package com.tikitaka.triptroop.admin.controller;
 
 
+import com.tikitaka.triptroop.admin.dto.response.AdminNoticeDetailResponse;
+import com.tikitaka.triptroop.admin.dto.response.AdminNoticeResponse;
 import com.tikitaka.triptroop.admin.service.AdminNoticeService;
 import com.tikitaka.triptroop.common.dto.response.ApiResponse;
-import com.tikitaka.triptroop.notice.domain.entity.Notice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,16 +24,16 @@ public class AdminNoticeController {
     /* 1. 공지 관리 > 공지 목록 조회 */
     @GetMapping("")
     public ResponseEntity<ApiResponse> getNoticeList() {
-        final List<Notice> noticeList = adminNoticeService.getNoticeList();
-        return ResponseEntity.ok(ApiResponse.success("공지 목록 조회에 성공하였습니다.", noticeList));
+        final List<AdminNoticeResponse> noticeList = adminNoticeService.getNoticeList();
+        return ResponseEntity.ok(ApiResponse.success("공", noticeList));
     }
 
-    /* 2. 지 관리 > 공지 상세 조회 */
-//    @GetMapping("/{noticeId}")
-//    public ResponseEntity<ApiResponse> getNoticeDetail(@PathVariable final Long noticeId) {
-//        final AdminInquiryDetailResponse inquiryDetail = inquiryService.getInquiryDetail(inquiryId);
-//        return ResponseEntity.ok(ApiResponse.success("문의 상세 조회에 성공하였습니다.", inquiryDetail));
-//    }
+    /* 2. 공지 관리 > 공지 상세 조회 */
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ApiResponse> getNoticeDetail(@PathVariable final Long noticeId) {
+        final AdminNoticeDetailResponse noticeDetail = adminNoticeService.getNoticeDetail(noticeId);
+        return ResponseEntity.ok(ApiResponse.success("문의 상세 조회에 성공하였습니다.", noticeDetail));
+    }
 //
 //    /* 3. 문의 관리 > 답변 등록 */
 //    @PatchMapping("/{inquiryId}/reply")

--- a/src/main/java/com/tikitaka/triptroop/admin/controller/AdminNoticeController.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/controller/AdminNoticeController.java
@@ -25,7 +25,7 @@ public class AdminNoticeController {
     @GetMapping("")
     public ResponseEntity<ApiResponse> getNoticeList() {
         final List<AdminNoticeResponse> noticeList = adminNoticeService.getNoticeList();
-        return ResponseEntity.ok(ApiResponse.success("공", noticeList));
+        return ResponseEntity.ok(ApiResponse.success("공지 목록 조회에 성공하였습니다.", noticeList));
     }
 
     /* 2. 공지 관리 > 공지 상세 조회 */

--- a/src/main/java/com/tikitaka/triptroop/admin/dto/request/AdminInquiryReplyRequest.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/dto/request/AdminInquiryReplyRequest.java
@@ -1,4 +1,4 @@
-package com.tikitaka.triptroop.image.dto.request;
+package com.tikitaka.triptroop.admin.dto.request;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminCategoryResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminCategoryResponse.java
@@ -3,10 +3,12 @@ package com.tikitaka.triptroop.admin.dto.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.tikitaka.triptroop.category.domain.entity.Category;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
+@RequiredArgsConstructor
 public class AdminCategoryResponse {
 
     private final Long categoryId;
@@ -16,11 +18,12 @@ public class AdminCategoryResponse {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private final LocalDateTime deletedAt;
 
-    public AdminCategoryResponse(final Category category) {
-        this.categoryId = category.getId();
-        this.name = category.getName();
-        this.createdAt = category.getCreatedAt();
-        this.deletedAt = category.getDeletedAt();
+    public static AdminCategoryResponse form(final Category category) {
+        return new AdminCategoryResponse(
+                category.getId(),
+                category.getName(),
+                category.getCreatedAt(),
+                category.getDeletedAt()
+        );
     }
-
 }

--- a/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminNoticeDetailResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminNoticeDetailResponse.java
@@ -1,5 +1,47 @@
 package com.tikitaka.triptroop.admin.dto.response;
 
-public class AdminNoticeDetailResponse {
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tikitaka.triptroop.image.dto.response.ImageOriginalResponse;
+import com.tikitaka.triptroop.image.util.ImageUtils;
+import com.tikitaka.triptroop.notice.domain.entity.Notice;
+import com.tikitaka.triptroop.notice.domain.type.NoticeKind;
+import com.tikitaka.triptroop.notice.domain.type.NoticeStatus;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class AdminNoticeDetailResponse {
+    private final Long noticeId;
+    private final NoticeKind kind;
+    private final boolean isRead;
+    private final String title;
+    private final String content;
+    private final NoticeStatus status;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime modifiedAt;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime deliveredAt;
+    private final List<String> imageNames;
+
+    public static AdminNoticeDetailResponse from(final Notice notice, List<ImageOriginalResponse> imageOriginalResponses) {
+        List<String> imageNames = ImageUtils.extractImageInfo(imageOriginalResponses);
+        return new AdminNoticeDetailResponse(
+                notice.getId(),
+                notice.getKind(),
+                notice.getIsRead(),
+                notice.getTitle(),
+                notice.getContent(),
+                notice.getStatus(),
+                notice.getCreatedAt(),
+                notice.getModifiedAt(),
+                notice.getDeliveredAt(),
+                imageNames
+        );
+    }
 }

--- a/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminNoticeResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/dto/response/AdminNoticeResponse.java
@@ -1,5 +1,30 @@
 package com.tikitaka.triptroop.admin.dto.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.tikitaka.triptroop.notice.domain.entity.Notice;
+import com.tikitaka.triptroop.notice.domain.type.NoticeKind;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@RequiredArgsConstructor
 public class AdminNoticeResponse {
 
+    private final Long noticeId;
+    private final NoticeKind kind;
+    private final String title;
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private final LocalDateTime createdAt;
+
+    public static AdminNoticeResponse from(final Notice notice) {
+        return new AdminNoticeResponse(
+                notice.getId(),
+                notice.getKind(),
+                notice.getTitle(),
+                notice.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/tikitaka/triptroop/admin/service/AdminCategoryService.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/service/AdminCategoryService.java
@@ -2,6 +2,7 @@ package com.tikitaka.triptroop.admin.service;
 
 import com.tikitaka.triptroop.admin.domain.repository.AdminCategoryRepository;
 import com.tikitaka.triptroop.admin.dto.request.AdminCategorySaveRequest;
+import com.tikitaka.triptroop.admin.dto.response.AdminCategoryResponse;
 import com.tikitaka.triptroop.category.domain.entity.Category;
 import com.tikitaka.triptroop.common.exception.NotFoundException;
 import com.tikitaka.triptroop.common.exception.type.ExceptionCode;
@@ -10,6 +11,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -20,9 +22,9 @@ public class AdminCategoryService {
 
     /* 1. 카테고리 관리 > 카테고리 목록 조회 */
     @Transactional(readOnly = true)
-    public List<Category> getCategoryList() {
-        return adminCategoryRepository.findAll();
-//        return adminCategoryRepository.findAdminCategoryAll();
+    public List<AdminCategoryResponse> getCategoryList() {
+        List<Category> categoryList = adminCategoryRepository.findAll();
+        return categoryList.stream().map(AdminCategoryResponse::form).collect(Collectors.toList());
     }
 
 

--- a/src/main/java/com/tikitaka/triptroop/admin/service/AdminInquiryService.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/service/AdminInquiryService.java
@@ -1,13 +1,13 @@
 package com.tikitaka.triptroop.admin.service;
 
 import com.tikitaka.triptroop.admin.domain.repository.AdminInquiryRepository;
+import com.tikitaka.triptroop.admin.dto.request.AdminInquiryReplyRequest;
 import com.tikitaka.triptroop.admin.dto.response.AdminInquiryDetailResponse;
 import com.tikitaka.triptroop.admin.dto.response.AdminInquiryListResponse;
 import com.tikitaka.triptroop.common.exception.NotFoundException;
 import com.tikitaka.triptroop.common.exception.type.ExceptionCode;
 import com.tikitaka.triptroop.image.domain.entity.Image;
 import com.tikitaka.triptroop.image.domain.repository.ImageRepository;
-import com.tikitaka.triptroop.image.dto.request.AdminInquiryReplyRequest;
 import com.tikitaka.triptroop.image.dto.response.ImageOriginalResponse;
 import com.tikitaka.triptroop.inquiry.domain.entity.Inquiry;
 import com.tikitaka.triptroop.user.domain.entity.Profile;

--- a/src/main/java/com/tikitaka/triptroop/admin/service/AdminNoticeService.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/service/AdminNoticeService.java
@@ -24,22 +24,22 @@ public class AdminNoticeService {
     private final AdminNoticeRepository adminNoticeRepository;
     private final ImageRepository imageRepository;
 
+    /* 1. 공지 관리 > 공지 목록 조회 */
     @Transactional(readOnly = true)
     public List<AdminNoticeResponse> getNoticeList() {
         List<Notice> notices = adminNoticeRepository.findAll();
         return notices.stream().map(AdminNoticeResponse::from).collect(Collectors.toList());
     }
 
+    /* 2. 공지 관리 > 공지 상세 조회 */
     @Transactional(readOnly = true)
     public AdminNoticeDetailResponse getNoticeDetail(Long noticeId) {
         Notice notice = adminNoticeRepository.findById(noticeId)
                 .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND_NOTICE));
-        System.out.println("notice : " + notice);
-
-        List<Image> images = imageRepository.findByInquiryId(noticeId);
+        
+        List<Image> images = imageRepository.findByNoticeId(noticeId);
         List<ImageOriginalResponse> imageOriginalResponses = ImageOriginalResponse.from(images);
-        System.out.println("images : " + images);
-        System.out.println("ImageOriginalResponse : " + imageOriginalResponses);
+
         return AdminNoticeDetailResponse.from(notice, imageOriginalResponses);
     }
 }

--- a/src/main/java/com/tikitaka/triptroop/admin/service/AdminNoticeService.java
+++ b/src/main/java/com/tikitaka/triptroop/admin/service/AdminNoticeService.java
@@ -1,12 +1,20 @@
 package com.tikitaka.triptroop.admin.service;
 
 import com.tikitaka.triptroop.admin.domain.repository.AdminNoticeRepository;
+import com.tikitaka.triptroop.admin.dto.response.AdminNoticeDetailResponse;
+import com.tikitaka.triptroop.admin.dto.response.AdminNoticeResponse;
+import com.tikitaka.triptroop.common.exception.NotFoundException;
+import com.tikitaka.triptroop.common.exception.type.ExceptionCode;
+import com.tikitaka.triptroop.image.domain.entity.Image;
+import com.tikitaka.triptroop.image.domain.repository.ImageRepository;
+import com.tikitaka.triptroop.image.dto.response.ImageOriginalResponse;
 import com.tikitaka.triptroop.notice.domain.entity.Notice;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Transactional
@@ -14,8 +22,24 @@ import java.util.List;
 public class AdminNoticeService {
 
     private final AdminNoticeRepository adminNoticeRepository;
+    private final ImageRepository imageRepository;
 
-    public List<Notice> getNoticeList() {
-        return adminNoticeRepository.findAll();
+    @Transactional(readOnly = true)
+    public List<AdminNoticeResponse> getNoticeList() {
+        List<Notice> notices = adminNoticeRepository.findAll();
+        return notices.stream().map(AdminNoticeResponse::from).collect(Collectors.toList());
+    }
+
+    @Transactional(readOnly = true)
+    public AdminNoticeDetailResponse getNoticeDetail(Long noticeId) {
+        Notice notice = adminNoticeRepository.findById(noticeId)
+                .orElseThrow(() -> new NotFoundException(ExceptionCode.NOT_FOUND_NOTICE));
+        System.out.println("notice : " + notice);
+
+        List<Image> images = imageRepository.findByInquiryId(noticeId);
+        List<ImageOriginalResponse> imageOriginalResponses = ImageOriginalResponse.from(images);
+        System.out.println("images : " + images);
+        System.out.println("ImageOriginalResponse : " + imageOriginalResponses);
+        return AdminNoticeDetailResponse.from(notice, imageOriginalResponses);
     }
 }

--- a/src/main/java/com/tikitaka/triptroop/block/dto/response/BlockTableResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/block/dto/response/BlockTableResponse.java
@@ -2,7 +2,6 @@ package com.tikitaka.triptroop.block.dto.response;
 
 import com.tikitaka.triptroop.block.domain.entity.Block;
 import com.tikitaka.triptroop.block.domain.type.BlockStatus;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -11,7 +10,7 @@ import org.springframework.data.annotation.LastModifiedDate;
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class BlockTableResponse {
 
     private final Long id;

--- a/src/main/java/com/tikitaka/triptroop/common/exception/type/ExceptionCode.java
+++ b/src/main/java/com/tikitaka/triptroop/common/exception/type/ExceptionCode.java
@@ -40,6 +40,7 @@ public enum ExceptionCode {
     NOT_FOUND_SCHEDULE(2008, "해당 일정이 존재하지 않습니다."),
     NOT_FOUND_SCHEDULE_ITEM(2009, "해당 계획이 존재하지 않습니다."),
     NOT_FOUND_INQUIRY(2000, "문의 내역이 존재하지 않습니다."),
+    NOT_FOUND_NOTICE(2010, "공지 내역이 존재하지 않습니다."),
     ALREADY_EXISTS_EMAIL(409, "이미 존재하는 이메일입니다."),
     ALREADY_EXISTS_PROFILE(409, "이미 프로필이 존재합니다."),
     ALREADY_EXISTS_NICKNAME(409, "이미 존재하는 닉네임입니다."),

--- a/src/main/java/com/tikitaka/triptroop/image/domain/entity/Image.java
+++ b/src/main/java/com/tikitaka/triptroop/image/domain/entity/Image.java
@@ -32,6 +32,8 @@ public class Image {
 
     private Long inquiryId;
 
+    private Long noticeId;
+
     @Enumerated(EnumType.STRING)
     private ImageKind kind;
 
@@ -65,6 +67,7 @@ public class Image {
             case TRAVEL -> this.travelId = id;
             case SCHEDULE -> this.scheduleId = id;
             case INQUIRY -> this.inquiryId = id;
+            case NOTICE -> this.noticeId = id;
             case COMPANION -> this.companionId = id;
         }
     }

--- a/src/main/java/com/tikitaka/triptroop/image/domain/repository/ImageRepository.java
+++ b/src/main/java/com/tikitaka/triptroop/image/domain/repository/ImageRepository.java
@@ -18,5 +18,5 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
     List<Image> findByInquiryId(Long id);
 
-
+    List<Image> findByNoticeId(Long id);
 }

--- a/src/main/java/com/tikitaka/triptroop/image/domain/type/ImageKind.java
+++ b/src/main/java/com/tikitaka/triptroop/image/domain/type/ImageKind.java
@@ -2,5 +2,5 @@ package com.tikitaka.triptroop.image.domain.type;
 
 public enum ImageKind {
 
-    TRAVEL, SCHEDULE, COMPANION, REPORT, INQUIRY
+    TRAVEL, SCHEDULE, COMPANION, REPORT, INQUIRY, NOTICE
 }

--- a/src/main/java/com/tikitaka/triptroop/image/service/ImageService.java
+++ b/src/main/java/com/tikitaka/triptroop/image/service/ImageService.java
@@ -56,6 +56,7 @@ public class ImageService {
             case COMPANION -> imageRepository.findByCompanionId(targetId);
             case REPORT -> imageRepository.findByReportId(targetId);
             case INQUIRY -> imageRepository.findByInquiryId(targetId);
+            case NOTICE -> imageRepository.findByNoticeId(targetId);
         };
     }
 

--- a/src/main/java/com/tikitaka/triptroop/notice/domain/entity/Notice.java
+++ b/src/main/java/com/tikitaka/triptroop/notice/domain/entity/Notice.java
@@ -26,7 +26,8 @@ public class Notice {
 
     @Enumerated(value = EnumType.STRING)
     private NoticeKind kind;
-    private String isRead;
+
+    private Boolean isRead;
     private String title;
     private String content;
 
@@ -40,34 +41,34 @@ public class Notice {
     private LocalDateTime modifiedAt;
     private LocalDateTime deliveredAt;
 
-    private Notice(
-            NoticeKind kind,
-            String isRead,
-            String title,
-            String content,
-            NoticeStatus status
-    ) {
-        this.kind = kind;
-        this.isRead = isRead;
-        this.title = title;
-        this.content = content;
-        this.status = status;
-    }
+//    private Notice(
+//            NoticeKind kind,
+//            String isRead,
+//            String title,
+//            String content,
+//            NoticeStatus status
+//    ) {
+//        this.kind = kind;
+//        this.isRead = isRead;
+//        this.title = title;
+//        this.content = content;
+//        this.status = status;
+//    }
 
-    public static Notice of(
-            NoticeKind kind,
-            String isRead,
-            String title,
-            String content,
-            NoticeStatus status
-    ) {
-        return new Notice(
-                kind,
-                isRead,
-                title,
-                content,
-                status
-        );
-    }
+//    public static Notice of(
+//            NoticeKind kind,
+//            String isRead,
+//            String title,
+//            String content,
+//            NoticeStatus status
+//    ) {
+//        return new Notice(
+//                kind,
+//                isRead,
+//                title,
+//                content,
+//                status
+//        );
+//    }
 
 }

--- a/src/main/java/com/tikitaka/triptroop/report/dto/response/ReportDetailResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/report/dto/response/ReportDetailResponse.java
@@ -7,7 +7,6 @@ import com.tikitaka.triptroop.report.domain.entity.Report;
 import com.tikitaka.triptroop.report.domain.type.ReportKind;
 import com.tikitaka.triptroop.report.domain.type.ReportProcessStatus;
 import com.tikitaka.triptroop.report.domain.type.ReportType;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -15,7 +14,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class ReportDetailResponse {
 
     private final Long id;

--- a/src/main/java/com/tikitaka/triptroop/report/dto/response/ReportTableResponse.java
+++ b/src/main/java/com/tikitaka/triptroop/report/dto/response/ReportTableResponse.java
@@ -5,14 +5,13 @@ import com.tikitaka.triptroop.report.domain.entity.Report;
 import com.tikitaka.triptroop.report.domain.type.ReportKind;
 import com.tikitaka.triptroop.report.domain.type.ReportProcessStatus;
 import com.tikitaka.triptroop.report.domain.type.ReportType;
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@RequiredArgsConstructor
 public class ReportTableResponse {
 
     private final Long reportId;


### PR DESCRIPTION
<!-- --------------------------------------------------------- -->
<!-- 제목 작성 규칙✅ : #이슈번호 이슈명 -->
<!-- [예시] #23 로그인 페이지 추가 -->
<!-- --------------------------------------------------------- -->


### 📫 PR 유형
<!-- 하나 이상의 PR 타입을 선택해주세요. -->
<!-- 해당하는 유형의 [] 내부에 x를 적어주세요. 중복 기입 가능 -->
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트

## 🚀 개요
<!-- 개요 작성 규칙✅ : PR 개요 및 이슈 번호를 입력하세요. --> 
<!-- 단, 종료된 이슈라면 closed #{이슈번호} 형태로 입력하세요. --> 
<!-- [예시] 🚀 #21 -->
> 간단한 개요 작성해주세요. 
- closed #137 

## 💻 작업 내용
- 공지 관리의 공지 목록 을 상세 조회하는  코드 추가 완료.
- 작업과정에서 관리자 컨트롤러단에 엔티티 쓰인것 발견 : 컨트롤러 단의 엔티티 -> dto 형식의 response 타입으로 변경후 서비스 단으로 이동
- 이미지 파일 조회 안되어 확인 해보니 CK 제약조건 빠져있었음 -> config  에서 추가 후  create.sql문 수정하여 푸쉬함

## 📚 참고
<!-- (선택사항) 작성이 필요한 경우만 추가 -->
[Method / url] http://localhost:8080/api/v1/admin/notice/1

[Request]
├─ [Method / url] : [GET] http://localhost:8080/api/v1/admin/notice/{noticeId}
├─ [Header - type / value] : -
└─ [Parameter - name / type / info] : noticeId / Long / 공지번호
[Response]
├─ [Header - type / value] : application / json
├─ [Parameter - name / type / info] : - 
└─ [Success Data Example - success / message / data] :
{
    "success": true,
    "message": "문의 상세 조회에 성공하였습니다.",
    "result": {
        "noticeId": 1,
        "kind": "NORMAL",
        "title": "일반 공지 테스트 제목임",
        "content": "일반 공지 내용 테스트 내용임",
        "status": "TODO",
        "createdAt": "2024-06-15 05:31:43",
        "modifiedAt": null,
        "deliveredAt": null,
        "imageNames": [
            "다운로드.jpeg",
            "ㄴㄴㅇㄹㄴㅇㄹㄴㅇㄹ.jpeg"
        ],
        "read": false
    }
}

<!-- --------------------------------------------------------- -->
<!-- PR 작성 시 확인 목록✅ -->
<!-- 1) 이슈와 기능에 맞는 라벨(label) 선택 -->
<!-- 2) 프로젝트(project) 선택 -->
<!-- 3) 마일스톤(milestone)선택 -->
<!-- --------------------------------------------------------- -->
